### PR TITLE
Don't convert potentially null interfaces to strings directly

### DIFF
--- a/baseline/workflow.go
+++ b/baseline/workflow.go
@@ -48,6 +48,13 @@ func (w *Workflow) CacheByBaselineID(baselineID string) error {
 	})
 }
 
+func stringFromInterface(value interface{}) *string {
+	if value == nil {
+		return nil
+	}
+	return common.StringOrNil(value.(string))
+}
+
 func baselineWorkflowFactory(objectType string, identifier *string) (*Workflow, error) {
 	var identifierUUID uuid.UUID
 	if identifier != nil {
@@ -83,9 +90,9 @@ func baselineWorkflowFactory(objectType string, identifier *string) (*Workflow, 
 	}
 	for _, org := range orgs {
 		workflow.Participants = append(workflow.Participants, &Participant{
-			Address:           common.StringOrNil(org.Metadata["address"].(string)),
-			APIEndpoint:       common.StringOrNil(org.Metadata["api_endpoint"].(string)),
-			MessagingEndpoint: common.StringOrNil(org.Metadata["messaging_endpoint"].(string)),
+			Address:           stringFromInterface(org.Metadata["address"]),
+			APIEndpoint:       stringFromInterface(org.Metadata["api_endpoint"]),
+			MessagingEndpoint: stringFromInterface(org.Metadata["messaging_endpoint"]),
 		})
 	}
 


### PR DESCRIPTION
While these maybe shouldn't be missing, it shouldn't cause a panic if they are.