### PR TITLE
validate WorkgroupID on Workflow.Validate method

### DIFF
--- a/baseline/workflow.go
+++ b/baseline/workflow.go
@@ -798,6 +798,13 @@ func (w *Workflow) Validate() bool {
 		return false
 	}
 
+	if w.WorkgroupID == nil {
+		w.Errors = append(w.Errors, &provide.Error{
+			Message: common.StringOrNil("workgroup_id is required"),
+		})
+		return false
+	}
+
 	if !w.isPrototype() {
 		proto = FindWorkflowByID(*w.WorkflowID)
 


### PR DESCRIPTION
current behavior - creating a workgroup without a workgroup_id in the POST body returns a SQL error.
fixed to catch in the Workflow Validate method.