### PR TITLE
Propogate domain models

### DIFF
--- a/baseline/handlers.go
+++ b/baseline/handlers.go
@@ -538,7 +538,7 @@ func acceptWorkgroupInvite(c *gin.Context, organizationID uuid.UUID, params map[
 		tx.Where("workgroup_id = ?", *claims.Baseline.WorkgroupID).Find(&mappings)
 
 		for _, m := range mappings {
-			result := db.Exec("INSERT INTO mappings_organizations (mapping_id, organization_id, permissions) VALUES (?, ?, ?)", m.ID, *subjectAccount.Metadata.OrganizationID, 0) // TODO-- default permission level ??
+			result := db.Exec("INSERT INTO organizations_mappings (organization_id, mapping_id, permissions) VALUES (?, ?, ?)", *subjectAccount.Metadata.OrganizationID, m.ID, 0) // TODO-- default permission level ??
 			rowsAffected := result.RowsAffected
 			errors := result.GetErrors()
 			if len(errors) > 0 {

--- a/baseline/handlers.go
+++ b/baseline/handlers.go
@@ -878,6 +878,11 @@ func createMappingHandler(c *gin.Context) {
 		return
 	}
 
+	if mapping.Ref != nil {
+		provide.RenderError("cannot specify ref", 400, c)
+		return
+	}
+
 	mapping.OrganizationID = organizationID
 
 	token, _ := util.ParseBearerAuthorizationHeader(c, nil)

--- a/baseline/handlers.go
+++ b/baseline/handlers.go
@@ -536,7 +536,7 @@ func acceptWorkgroupInvite(c *gin.Context, organizationID uuid.UUID, params map[
 		// give new organization access to all workgroup domain models
 		var mappings []*Mapping
 		tx.Where("workgroup_id = ?", *claims.Baseline.WorkgroupID).Find(&mappings)
-		
+
 		for _, m := range mappings {
 			result := db.Exec("INSERT INTO mappings_organizations (mapping_id, organization_id, permissions) VALUES (?, ?, ?)", m.ID, *subjectAccount.Metadata.OrganizationID, 0) // TODO-- default permission level ??
 			rowsAffected := result.RowsAffected
@@ -830,7 +830,7 @@ func listMappingsHandler(c *gin.Context) {
 	var mappings []*Mapping
 
 	query := FindMappingsByOrganizationID(*organizationID)
-	
+
 	if c.Query("workgroup_id") != "" {
 		workgroupID, err := uuid.FromString(c.Query("workgroup_id"))
 		if err != nil {
@@ -924,10 +924,10 @@ func updateMappingHandler(c *gin.Context) {
 		return
 	}
 
-	if *mapping.OrganizationID != *organizationID {
-		provide.RenderError("forbidden", 403, c)
-		return
-	}
+	// if *mapping.OrganizationID != *organizationID {
+	// 	provide.RenderError("forbidden", 403, c)
+	// 	return
+	// }
 
 	_mapping := &Mapping{}
 	err = json.Unmarshal(buf, _mapping)

--- a/baseline/handlers.go
+++ b/baseline/handlers.go
@@ -518,27 +518,12 @@ func acceptWorkgroupInvite(c *gin.Context, organizationID uuid.UUID, params map[
 			return
 		}
 
-		// give other workgroup participants access to new organization domain models wip -- currently solved by creating mappings after invitation has been accepted
-
-		// token, _ := util.ParseBearerAuthorizationHeader(c, nil)
-		// wg_orgs, err := ident.ListApplicationOrganizations(token.Raw, *claims.Baseline.WorkgroupID, map[string]interface{}{})
-		// if err != nil {
-		// 	subjectAccount.Errors = append(subjectAccount.Errors, &api.Error{
-		// 		Message: common.StringOrNil(err.Error()),
-		// 	})
-
-		// 	obj := map[string]interface{}{}
-		// 	obj["errors"] = subjectAccount.Errors
-		// 	provide.Render(obj, 422, c)
-		// 	return
-		// }
-
 		// give new organization access to all workgroup domain models
 		var mappings []*Mapping
 		tx.Where("workgroup_id = ?", *claims.Baseline.WorkgroupID).Find(&mappings)
 
 		for _, m := range mappings {
-			result := db.Exec("INSERT INTO organizations_mappings (organization_id, mapping_id, permissions) VALUES (?, ?, ?)", *subjectAccount.Metadata.OrganizationID, m.ID, 0) // TODO-- default permission level ??
+			result := db.Exec("INSERT INTO organizations_mappings (organization_id, mapping_id, permissions) VALUES (?, ?, ?)", *subjectAccount.Metadata.OrganizationID, m.ID, DefaultOrganizationMappingPermission)
 			rowsAffected := result.RowsAffected
 			errors := result.GetErrors()
 			if len(errors) > 0 {
@@ -924,6 +909,7 @@ func updateMappingHandler(c *gin.Context) {
 		return
 	}
 
+	// TODO-- make update mapping permissions more fine-grained so that participants can only update certain fields of operator mappings
 	// if *mapping.OrganizationID != *organizationID {
 	// 	provide.RenderError("forbidden", 403, c)
 	// 	return

--- a/baseline/mapping.go
+++ b/baseline/mapping.go
@@ -71,8 +71,8 @@ type MappingField struct {
 // MappingsByOrganizationID returns a query to a list of mappings which are associated with the given organization id
 func FindMappingsByOrganizationID(organizationID uuid.UUID) *gorm.DB {
 	db := dbconf.DatabaseConnection()
-	query := db.Where("mo.organization_id = ?", organizationID.String())
-	return query.Joins("JOIN mappings_organizations as mo ON mo.mapping_id = mappings.id")
+	query := db.Where("om.organization_id = ?", organizationID.String())
+	return query.Joins("JOIN organizations_mappings as om ON om.mapping_id = mappings.id")
 }
 
 func mappingRefFactory(organizationID uuid.UUID, mappingType string) string {
@@ -166,7 +166,7 @@ func (m *Mapping) Create(token string) bool {
 		}
 
 		for _, wg_org := range wg_orgs {
-			result = db.Exec("INSERT INTO mappings_organizations (mapping_id, organization_id, permissions) VALUES (?, ?, ?)", m.ID, *wg_org.ID, 0)
+			result = db.Exec("INSERT INTO organizations_mappings (organization_id, mapping_id, permissions) VALUES (?, ?, ?)", *wg_org.ID, m.ID, 0)
 			rowsAffected = result.RowsAffected
 			errors = result.GetErrors()
 			if len(errors) > 0 {

--- a/baseline/mapping.go
+++ b/baseline/mapping.go
@@ -302,31 +302,31 @@ func (m *MappingModel) Create(tx *gorm.DB) bool {
 	common.Log.Tracef("attempting to create mapping model for mapping: %s", m.MappingID)
 
 	success := false
-	if tx.NewRecord(m) {
-		result := tx.Create(&m)
-		rowsAffected := result.RowsAffected
-		errors := result.GetErrors()
-		if len(errors) > 0 {
-			for _, err := range errors {
-				m.Errors = append(m.Errors, &provide.Error{
-					Message: common.StringOrNil(err.Error()),
-				})
-			}
+	// if tx.NewRecord(m) {
+	result := tx.Create(&m)
+	rowsAffected := result.RowsAffected
+	errors := result.GetErrors()
+	if len(errors) > 0 {
+		for _, err := range errors {
+			m.Errors = append(m.Errors, &provide.Error{
+				Message: common.StringOrNil(err.Error()),
+			})
 		}
-		if !tx.NewRecord(m) {
-			success = rowsAffected > 0
-			if success {
-				for _, field := range m.Fields {
-					field.MappingModelID = m.ID
-					if !field.Create(tx) {
-						common.Log.Warningf("failed to create mapping model field; transaction will be rolled back")
-						m.Errors = append(m.Errors, field.Errors...)
-						return false
-					}
+	}
+	if !tx.NewRecord(m) {
+		success = rowsAffected > 0
+		if success {
+			for _, field := range m.Fields {
+				field.MappingModelID = m.ID
+				if !field.Create(tx) {
+					common.Log.Warningf("failed to create mapping model field; transaction will be rolled back")
+					m.Errors = append(m.Errors, field.Errors...)
+					return false
 				}
 			}
 		}
 	}
+	// }
 
 	return success
 }
@@ -343,21 +343,21 @@ func (f *MappingField) Create(tx *gorm.DB) bool {
 	common.Log.Tracef("attempting to create mapping model field for model: %s", f.MappingModelID)
 
 	success := false
-	if tx.NewRecord(f) {
-		result := tx.Create(&f)
-		rowsAffected := result.RowsAffected
-		errors := result.GetErrors()
-		if len(errors) > 0 {
-			for _, err := range errors {
-				f.Errors = append(f.Errors, &provide.Error{
-					Message: common.StringOrNil(err.Error()),
-				})
-			}
-		}
-		if !tx.NewRecord(f) {
-			success = rowsAffected > 0
+	// if tx.NewRecord(f) {
+	result := tx.Create(&f)
+	rowsAffected := result.RowsAffected
+	errors := result.GetErrors()
+	if len(errors) > 0 {
+		for _, err := range errors {
+			f.Errors = append(f.Errors, &provide.Error{
+				Message: common.StringOrNil(err.Error()),
+			})
 		}
 	}
+	if !tx.NewRecord(f) {
+		success = rowsAffected > 0
+	}
+	// }
 
 	return success
 }

--- a/baseline/mapping.go
+++ b/baseline/mapping.go
@@ -263,6 +263,12 @@ func (m *Mapping) Update(mapping *Mapping) bool {
 }
 
 func (m *Mapping) Validate() bool {
+	if m.WorkgroupID == nil {
+		m.Errors = append(m.Errors, &provide.Error{
+			Message: common.StringOrNil("workgroup_id is required"),
+		})
+	}
+
 	if m.Ref != nil {
 		m.Errors = append(m.Errors, &provide.Error{
 			Message: common.StringOrNil("mapping ref must not be provided"),

--- a/baseline/mapping.go
+++ b/baseline/mapping.go
@@ -68,6 +68,8 @@ type MappingField struct {
 	RefFieldID     *uuid.UUID `json:"ref_field_id"`
 }
 
+const DefaultOrganizationMappingPermission = 510
+
 // MappingsByOrganizationID returns a query to a list of mappings which are associated with the given organization id
 func FindMappingsByOrganizationID(organizationID uuid.UUID) *gorm.DB {
 	db := dbconf.DatabaseConnection()
@@ -166,7 +168,7 @@ func (m *Mapping) Create(token string) bool {
 		}
 
 		for _, wg_org := range wg_orgs {
-			result = db.Exec("INSERT INTO organizations_mappings (organization_id, mapping_id, permissions) VALUES (?, ?, ?)", *wg_org.ID, m.ID, 0)
+			result = db.Exec("INSERT INTO organizations_mappings (organization_id, mapping_id, permissions) VALUES (?, ?, ?)", *wg_org.ID, m.ID, DefaultOrganizationMappingPermission)
 			rowsAffected = result.RowsAffected
 			errors = result.GetErrors()
 			if len(errors) > 0 {
@@ -302,7 +304,7 @@ func (m *MappingModel) Create(tx *gorm.DB) bool {
 	common.Log.Tracef("attempting to create mapping model for mapping: %s", m.MappingID)
 
 	success := false
-	// if tx.NewRecord(m) {
+
 	result := tx.Create(&m)
 	rowsAffected := result.RowsAffected
 	errors := result.GetErrors()
@@ -313,6 +315,7 @@ func (m *MappingModel) Create(tx *gorm.DB) bool {
 			})
 		}
 	}
+
 	if !tx.NewRecord(m) {
 		success = rowsAffected > 0
 		if success {
@@ -326,7 +329,6 @@ func (m *MappingModel) Create(tx *gorm.DB) bool {
 			}
 		}
 	}
-	// }
 
 	return success
 }
@@ -343,7 +345,7 @@ func (f *MappingField) Create(tx *gorm.DB) bool {
 	common.Log.Tracef("attempting to create mapping model field for model: %s", f.MappingModelID)
 
 	success := false
-	// if tx.NewRecord(f) {
+
 	result := tx.Create(&f)
 	rowsAffected := result.RowsAffected
 	errors := result.GetErrors()
@@ -354,10 +356,10 @@ func (f *MappingField) Create(tx *gorm.DB) bool {
 			})
 		}
 	}
+
 	if !tx.NewRecord(f) {
 		success = rowsAffected > 0
 	}
-	// }
 
 	return success
 }

--- a/ops/migrations/000007_add_organizations_mappings.down.sql
+++ b/ops/migrations/000007_add_organizations_mappings.down.sql
@@ -1,7 +1,7 @@
--- ALTER TABLE ONLY mappings_organizations DROP CONSTRAINT mappings_mapping_id_mappings_id_foreign;
--- ALTER TABLE ONLY mappings_organizations DROP CONSTRAINT organizations_organization_id_organizations_id_foreign;
+-- ALTER TABLE ONLY organizations_mappings DROP CONSTRAINT mappings_mapping_id_mappings_id_foreign;
+-- ALTER TABLE ONLY organizations_mappings DROP CONSTRAINT organizations_organization_id_organizations_id_foreign;
 
-DROP TABLE mappings_organizations;
+DROP TABLE organizations_mappings;
 
 -- DROP INDEX idx_mappings_workgroup_id;
 

--- a/ops/migrations/000007_add_organizations_mappings.down.sql
+++ b/ops/migrations/000007_add_organizations_mappings.down.sql
@@ -1,0 +1,11 @@
+-- ALTER TABLE ONLY mappings_organizations DROP CONSTRAINT mappings_mapping_id_mappings_id_foreign;
+-- ALTER TABLE ONLY mappings_organizations DROP CONSTRAINT organizations_organization_id_organizations_id_foreign;
+
+DROP TABLE mappings_organizations;
+
+-- DROP INDEX idx_mappings_workgroup_id;
+
+-- ALTER TABLE ONLY public.mappings ADD COLUMN organization_id uuid;
+
+-- CREATE INDEX idx_mappings_organization_id_workgroup_id ON public.mappings USING btree (organization_id, workgroup_id);
+

--- a/ops/migrations/000007_add_organizations_mappings.down.sql
+++ b/ops/migrations/000007_add_organizations_mappings.down.sql
@@ -1,11 +1,1 @@
--- ALTER TABLE ONLY organizations_mappings DROP CONSTRAINT mappings_mapping_id_mappings_id_foreign;
--- ALTER TABLE ONLY organizations_mappings DROP CONSTRAINT organizations_organization_id_organizations_id_foreign;
-
 DROP TABLE organizations_mappings;
-
--- DROP INDEX idx_mappings_workgroup_id;
-
--- ALTER TABLE ONLY public.mappings ADD COLUMN organization_id uuid;
-
--- CREATE INDEX idx_mappings_organization_id_workgroup_id ON public.mappings USING btree (organization_id, workgroup_id);
-

--- a/ops/migrations/000007_add_organizations_mappings.up.sql
+++ b/ops/migrations/000007_add_organizations_mappings.up.sql
@@ -1,15 +1,15 @@
--- mappings_organizations join table
+-- organizations_mappings join table
 
-CREATE TABLE mappings_organizations (
-    mapping_id uuid DEFAULT uuid_generate_v4() NOT NULL,
+CREATE TABLE organizations_mappings (
     organization_id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    mapping_id uuid DEFAULT uuid_generate_v4() NOT NULL,
     permissions integer DEFAULT 0 NOT NULL
 );
 
-ALTER TABLE ONLY mappings_organizations ADD CONSTRAINT mappings_organizations_pkey PRIMARY KEY (organization_id, mapping_id);
--- ALTER TABLE ONLY mappings_organizations ADD CONSTRAINT mappings_mapping_id_mappings_id_foreign FOREIGN KEY (mapping_id) REFERENCES mappings(id) ON UPDATE CASCADE ON DELETE CASCADE;
+ALTER TABLE ONLY organizations_mappings ADD CONSTRAINT organizations_mappings_pkey PRIMARY KEY (mapping_id, organization_id);
+-- ALTER TABLE ONLY organizations_mappings ADD CONSTRAINT mappings_mapping_id_mappings_id_foreign FOREIGN KEY (mapping_id) REFERENCES mappings(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
--- ALTER TABLE ONLY mappings_organizations ADD CONSTRAINT mappings_organization_id_organizations_id_foreign FOREIGN KEY (organization_id) REFERENCES organizations(id) ON UPDATE CASCADE ON DELETE CASCADE;
+-- ALTER TABLE ONLY organizations_mappings ADD CONSTRAINT mappings_organization_id_organizations_id_foreign FOREIGN KEY (organization_id) REFERENCES organizations(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 -- -- remove organization_id from mappings
 

--- a/ops/migrations/000007_add_organizations_mappings.up.sql
+++ b/ops/migrations/000007_add_organizations_mappings.up.sql
@@ -1,0 +1,22 @@
+-- mappings_organizations join table
+
+CREATE TABLE mappings_organizations (
+    mapping_id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    organization_id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    permissions integer DEFAULT 0 NOT NULL
+);
+
+ALTER TABLE ONLY mappings_organizations ADD CONSTRAINT mappings_organizations_pkey PRIMARY KEY (organization_id, mapping_id);
+-- ALTER TABLE ONLY mappings_organizations ADD CONSTRAINT mappings_mapping_id_mappings_id_foreign FOREIGN KEY (mapping_id) REFERENCES mappings(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+-- ALTER TABLE ONLY mappings_organizations ADD CONSTRAINT mappings_organization_id_organizations_id_foreign FOREIGN KEY (organization_id) REFERENCES organizations(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+-- -- remove organization_id from mappings
+
+-- DROP INDEX idx_mappings_organization_id_workgroup_id;
+
+-- ALTER TABLE ONLY public.mappings DROP COLUMN organization_id;
+
+-- -- index workgroup_id
+
+-- CREATE INDEX idx_mappings_workgroup_id ON public.mappings USING btree (workgroup_id);

--- a/ops/migrations/000007_add_organizations_mappings.up.sql
+++ b/ops/migrations/000007_add_organizations_mappings.up.sql
@@ -7,16 +7,3 @@ CREATE TABLE organizations_mappings (
 );
 
 ALTER TABLE ONLY organizations_mappings ADD CONSTRAINT organizations_mappings_pkey PRIMARY KEY (mapping_id, organization_id);
--- ALTER TABLE ONLY organizations_mappings ADD CONSTRAINT mappings_mapping_id_mappings_id_foreign FOREIGN KEY (mapping_id) REFERENCES mappings(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
--- ALTER TABLE ONLY organizations_mappings ADD CONSTRAINT mappings_organization_id_organizations_id_foreign FOREIGN KEY (organization_id) REFERENCES organizations(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
--- -- remove organization_id from mappings
-
--- DROP INDEX idx_mappings_organization_id_workgroup_id;
-
--- ALTER TABLE ONLY public.mappings DROP COLUMN organization_id;
-
--- -- index workgroup_id
-
--- CREATE INDEX idx_mappings_workgroup_id ON public.mappings USING btree (workgroup_id);


### PR DESCRIPTION
currently workgroup participants are unable to see the other domain models of the other participants. this issue is fixed by implementing an `organizations_mappings` JOIN table that establishes a many-to-many relationship between mappings and organization_ids